### PR TITLE
emuMMC Fast Mode

### DIFF
--- a/nyx/nyx_gui/frontend/fe_emummc_tools.c
+++ b/nyx/nyx_gui/frontend/fe_emummc_tools.c
@@ -530,6 +530,7 @@ static int _dump_emummc_raw_part(emmc_tool_gui_t *gui, int active_part, int part
 	lv_obj_set_opa_scale(gui->label_pct, LV_OPA_COVER);
 
 	u32 user_offset = 0;
+	bool fast_mode = (resized_count == EMUMMC_RAW_FAST_MODE);
 
 	if (resized_count)
 	{
@@ -655,7 +656,7 @@ static int _dump_emummc_raw_part(emmc_tool_gui_t *gui, int active_part, int part
 		sdmmc_storage_write(&sd_storage, 0, 1, &mbr);
 	}
 
-	if (resized_count)
+	if (resized_count && !fast_mode)
 	{
 		lv_label_ins_text(gui->label_log, LV_LABEL_POS_LAST, "Done!\n");
 
@@ -849,7 +850,7 @@ void dump_emummc_raw(emmc_tool_gui_t *gui, int part_idx, u32 sector_start, u32 r
 		goto out;
 	}
 
-	if (resized_count && !emummc_raw_derive_bis_keys())
+	if (resized_count && resized_count != EMUMMC_RAW_FAST_MODE && !emummc_raw_derive_bis_keys())
 	{
 		s_printf(gui->txt_buf, "#FFDD00 For formatting USER partition,#\n#FFDD00 BIS keys are needed!#\n");
 		lv_label_ins_text(gui->label_log, LV_LABEL_POS_LAST, gui->txt_buf);

--- a/nyx/nyx_gui/frontend/fe_emummc_tools.h
+++ b/nyx/nyx_gui/frontend/fe_emummc_tools.h
@@ -20,6 +20,8 @@
 
 #include "gui.h"
 
+#define EMUMMC_RAW_FAST_MODE 1
+
 typedef struct _emummc_cfg_t
 {
 	int  enabled;

--- a/nyx/nyx_gui/frontend/gui_emummc_tools.c
+++ b/nyx/nyx_gui/frontend/gui_emummc_tools.c
@@ -36,6 +36,7 @@ typedef struct _mbr_ctxt_t
 } mbr_ctxt_t;
 
 static bool emummc_backup;
+static bool emummc_fast_mode;
 static mbr_ctxt_t mbr_ctx;
 static lv_obj_t *emummc_manage_window;
 static lv_res_t (*emummc_tools)(lv_obj_t *btn);
@@ -134,7 +135,12 @@ static void _create_window_emummc()
 	if (!mbr_ctx.part_idx)
 		dump_emummc_file(&emmc_tool_gui_ctxt);
 	else
-		dump_emummc_raw(&emmc_tool_gui_ctxt, mbr_ctx.part_idx, mbr_ctx.sector_start, mbr_ctx.resized_cnt[mbr_ctx.part_idx - 1]);
+	{
+		u32 resized = mbr_ctx.resized_cnt[mbr_ctx.part_idx - 1];
+		if (!resized && emummc_fast_mode)
+			resized = EMUMMC_RAW_FAST_MODE;
+		dump_emummc_raw(&emmc_tool_gui_ctxt, mbr_ctx.part_idx, mbr_ctx.sector_start, resized);
+	}
 
 	nyx_window_toggle_buttons(win, false);
 }
@@ -154,6 +160,63 @@ static lv_res_t _create_emummc_raw_format(lv_obj_t * btns, const char * txt)
 	mbr_ctx.sector_start = 0;
 
 	return LV_RES_INV;
+}
+
+static void _create_mbox_emummc_raw_fast();
+
+static lv_res_t _create_emummc_raw_fast_action(lv_obj_t *btns, const char *txt)
+{
+	int btn_idx = lv_btnm_get_pressed(btns);
+	lv_obj_t *bg = lv_obj_get_parent(lv_obj_get_parent(btns));
+
+	switch (btn_idx)
+	{
+	case 0: // Default.
+		emummc_fast_mode = false;
+		break;
+	case 1: // Fast Mode.
+		emummc_fast_mode = true;
+		break;
+	case 2: // Cancel.
+	default:
+		mbr_ctx.part_idx = 0;
+		mbr_ctx.sector_start = 0;
+		nyx_mbox_action(btns, txt);
+		return LV_RES_INV;
+	}
+
+	lv_obj_set_style(bg, &lv_style_transp);
+	_create_window_emummc();
+
+	mbr_ctx.part_idx = 0;
+	mbr_ctx.sector_start = 0;
+
+	nyx_mbox_action(btns, txt);
+
+	return LV_RES_INV;
+}
+
+static void _create_mbox_emummc_raw_fast()
+{
+	lv_obj_t *dark_bg = lv_obj_create(lv_scr_act(), NULL);
+	lv_obj_set_style(dark_bg, &mbox_darken);
+	lv_obj_set_size(dark_bg, LV_HOR_RES, LV_VER_RES);
+
+	static const char *mbox_btn_map[] = { "\222Default", "\222Fast Mode", "\222Cancel", "" };
+	lv_obj_t *mbox = lv_mbox_create(dark_bg, NULL);
+	lv_mbox_set_recolor_text(mbox, true);
+	lv_obj_set_width(mbox, LV_HOR_RES / 9 * 6);
+
+	lv_mbox_set_text(mbox,
+		"#FF8000 Choose emuMMC creation mode:#\n\n"
+		"#C7EA46 Default:#\nFull copy of all partitions.\n\n"
+		"#C7EA46 Fast Mode (formatted):#\nCopies system partitions only.\n"
+		"USER partition left empty for formatting.");
+
+	lv_mbox_add_btns(mbox, mbox_btn_map, _create_emummc_raw_fast_action);
+
+	lv_obj_align(mbox, NULL, LV_ALIGN_CENTER, 0, 0);
+	lv_obj_set_top(mbox, true);
 }
 
 static lv_res_t _create_emummc_raw_action(lv_obj_t * btns, const char * txt)
@@ -183,6 +246,16 @@ static lv_res_t _create_emummc_raw_action(lv_obj_t * btns, const char * txt)
 
 	if (btn_idx < 3)
 	{
+		if (mbr_ctx.resized_cnt[mbr_ctx.part_idx - 1] == 0)
+		{
+			// Full-size partition: show fast mode selection.
+			nyx_mbox_action(btns, txt);
+			_create_mbox_emummc_raw_fast();
+			return LV_RES_INV;
+		}
+
+		// Resized partition: proceed directly.
+		emummc_fast_mode = false;
 		lv_obj_set_style(bg, &lv_style_transp);
 		_create_window_emummc();
 	}


### PR DESCRIPTION
emuMMC Fast Mode: 

when creating raw partition emuMMC on a
full-size
<img width="1280" height="720" alt="nyx20250101_031249" src="https://github.com/user-attachments/assets/e4355121-deb0-47f5-b0ea-96621c9e322e" />

 partition, user can choose "Fast Mode" which copies
only system partitions (BOOT0/1 + pre-USER GPP), skipping the
USER partition data. 

Full-size layout preserved, USER left empty
for user to format. Cuts creation from ~20min to ~5min.

Uses sentinel value (resized_count=1) to avoid new parameters.

only affects FULLSIZED/ nontrimmed emummc raw partition only.
